### PR TITLE
feat: activate and deactivate extension

### DIFF
--- a/src/components/blockSettings/BlockAlways.tsx
+++ b/src/components/blockSettings/BlockAlways.tsx
@@ -2,10 +2,13 @@ import React, {useState} from 'react'
 
 import { Button } from '~components/ui/button'
 import { Switch } from '~components/ui/switch'
+import { useActivateExtension } from '~hooks/useActivateExtension'
 
 export default function BlockAlways() {
   const [isScheduled, setIsScheduled] = useState(false)
   const [isPersonalMode, setIsPersonalMode] = useState(false)
+
+  const { isExtensionActive, handleActivateExtension } = useActivateExtension()
 
   const handleScheduled = () => {
     setIsScheduled(!isScheduled)
@@ -24,13 +27,14 @@ export default function BlockAlways() {
         <p className={`text-sm font-bold  ${isScheduled ? 'text-primary': 'text-gray-500'}`}>Schedule</p>
       </div>
       <Button
-        aria-label="activate"
+        aria-label="activate-extension"
         type="button"
         variant="default"
         size="default"
         className="px-10"
+        onClick={handleActivateExtension}
       >
-        Activate
+        {isExtensionActive ? "Deactivate" : "Activate"}
       </Button>
     </div>
     {/* Work Mode Switch */}

--- a/src/hooks/useActivateExtension.ts
+++ b/src/hooks/useActivateExtension.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react'
+import toast, { toastConfig } from 'react-simple-toasts'
+
+import { Storage } from '@plasmohq/storage'
+
+const storage = new Storage()
+
+export const useActivateExtension = () => {
+  const [isExtensionActive, setIsExtensionActive] = useState<boolean>()
+
+  const handleActivateExtension = async () => {
+    setIsExtensionActive(prev => !prev)
+    await storage.set('isExtensionActive', !isExtensionActive)
+    handleToast()
+  }
+
+  const handleToast = () =>
+    !isExtensionActive
+      ? toast('Extension Activated!', {
+          position: 'top-right',
+          theme: 'success',
+        })
+      : toast('Extension Deactivated!', {
+          position: 'top-right',
+          theme: 'success',
+        })
+        
+  useEffect(() => {
+    storage
+      .get('isExtensionActive')
+      .then(state => setIsExtensionActive(state ? Boolean(state) : false))
+  }, [])
+  return { isExtensionActive, handleActivateExtension }
+}

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -11,6 +11,8 @@ import { Storage } from "@plasmohq/storage"
 import { Button } from "~components/ui/button"
 import { Input } from "~components/ui/input"
 import { Switch } from "~components/ui/switch"
+import { useActivateExtension } from '~hooks/useActivateExtension'
+
 import {
   blockUrl,
   extractHostname,
@@ -29,6 +31,8 @@ function IndexPopup() {
   const [currentUrl, setCurrentUrl] = useState<string>("")
   const [blockedWebsites, setBlockedWebsites] = useState<any>([])
 
+  const { isExtensionActive } = useActivateExtension()
+
   const getCurrentUrl: () => Promise<string> = async () => {
     const url = await getCurrentTabUrl()
     setCurrentUrl(url)
@@ -45,7 +49,11 @@ function IndexPopup() {
   }
   const disableBlock = () => {
     const match = extractHostname(currentUrl)
-    return blockedWebsites.includes(match) || !isValidURL(currentUrl)
+    return (
+      blockedWebsites.includes(match) ||
+      !isValidURL(currentUrl) ||
+      !isExtensionActive
+    )
   }
 
   useEffect(() => {


### PR DESCRIPTION
Resolves #31 (Issue number this PR resolves)

### What does this PR do?

- Users will be able to activate and deactivate the extension from the block settings page.
- Users will be unable to block a website when the extension is deactivated.

### Screenshot 
<img width="951" alt="Screenshot 2024-01-21 210853" src="https://github.com/DotCampus/focus-defender/assets/92611151/c3f2d271-5f71-4ba0-8dab-7a0448028052">
<img width="958" alt="Screenshot 2024-01-21 210909" src="https://github.com/DotCampus/focus-defender/assets/92611151/57a0418e-fe39-4963-be0b-0656e76d5b6d">

